### PR TITLE
[NOJIRA] restore py_roslib_slim

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,6 +12,7 @@ py_library(
         "//third_party/roslib:__init__.py",
         "//third_party/roslib:message.py",
         "//third_party/roslib:names.py",
+        "//third_party/roslib:packages.py",
     ],
     imports = ["third_party"],
     visibility = ["//visibility:public"],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,6 +7,21 @@ exports_files([
 ])
 
 py_library(
+    name = "py_roslib_slim",
+    srcs = [
+        "//third_party/roslib:__init__.py",
+        "//third_party/roslib:message.py",
+        "//third_party/roslib:names.py",
+    ],
+    imports = ["third_party"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@ros_genmsg//:genmsg",
+        "@ros_genpy//:genpy",
+    ],
+)
+
+py_library(
     name = "dynamic_reconfigure",
     srcs = ["//third_party/dynamic_reconfigure:parameter_generator.py"],
     imports = ["third_party"],
@@ -22,7 +37,7 @@ alias(
     name = "rosgraph",
     actual = "@ros_comm//:rosgraph",
 )
- 
+
 alias(
     name = "rosparam",
     actual = "@ros_comm//:rosparam",

--- a/repositories/ros_comm.BUILD.bazel
+++ b/repositories/ros_comm.BUILD.bazel
@@ -336,6 +336,7 @@ py_library(
     deps = [
         ":py_topic_tools",
         ":rospy",
+        "@com_github_mvukov_rules_ros//:py_roslib_slim",
         requirement("gnupg"),
         requirement("pycryptodomex"),
         requirement("rospkg"),
@@ -350,6 +351,7 @@ py_library(
     deps = [
         ":py_roscpp",
         ":rosgraph_lib",
+        "@com_github_mvukov_rules_ros//:py_roslib_slim",
         "@ros_comm_msgs//:py_rosgraph_msgs",
         "@ros_genpy//:genpy",
         "@ros_std_msgs//:py_std_msgs",

--- a/ros/interfaces.bzl
+++ b/ros/interfaces.bzl
@@ -41,7 +41,7 @@ _ACTION_OUTPUT_MAPPING = [
 ]
 
 def _ros_interface_library_impl(ctx):
-    ros_package_name = ctx.label.name 
+    ros_package_name = ctx.label.name
     if ctx.attr.strip_end and "interface" in ros_package_name:
         ros_package_name = ros_package_name.split("_")
         ros_package_name = "_".join(ros_package_name[0:-1])
@@ -103,7 +103,7 @@ ros_interface_library = rule(
             doc = " A list of other `ros_interface_library` targets. ",
         ),
         "strip_end": attr.bool(
-            doc = "An override to override the ros pkg name. Use this to avoid changing import paths. Warning: Fragile"
+            doc = "An override to override the ros pkg name. Use this to avoid changing import paths. Warning: Fragile",
         ),
         "_genaction": attr.label(
             default = Label("@ros_common_msgs//:genaction"),
@@ -203,7 +203,7 @@ def _cc_ros_generator_aspect_impl(target, ctx):
 
 cc_ros_generator_aspect = aspect(
     implementation = _cc_ros_generator_aspect_impl,
-    attr_aspects = ["deps" , "strip_end"],
+    attr_aspects = ["deps", "strip_end"],
     attrs = {
         "_gencpp": attr.label(
             default = Label("@ros_gencpp//:gencpp"),
@@ -211,7 +211,7 @@ cc_ros_generator_aspect = aspect(
             cfg = "exec",
         ),
         "strip_end": attr.bool(
-            doc = "An override to override the ros pkg name. Use this to avoid changing import paths. Warning: Fragile"
+            doc = "An override to override the ros pkg name. Use this to avoid changing import paths. Warning: Fragile",
         ),
     },
     provides = [CcInfo],
@@ -233,7 +233,7 @@ cc_ros_generator = rule(
             providers = [RosInterfaceInfo],
         ),
         "strip_end": attr.bool(
-            doc = "An override to override the ros pkg name. Use this to avoid changing import paths. Warning: Fragile"
+            doc = "An override to override the ros pkg name. Use this to avoid changing import paths. Warning: Fragile",
         ),
     },
 )
@@ -422,7 +422,7 @@ py_ros_generator_aspect = aspect(
             cfg = "exec",
         ),
         "strip_end": attr.bool(
-            doc = "An override to override the ros pkg name. Use this to avoid changing import paths. Warning: Fragile"
+            doc = "An override to override the ros pkg name. Use this to avoid changing import paths. Warning: Fragile",
         ),
     },
     provides = [PyRosGeneratorAspectInfo],
@@ -453,7 +453,7 @@ py_ros_generator = rule(
             providers = [RosInterfaceInfo],
         ),
         "strip_end": attr.bool(
-            doc = "An override to override the ros pkg name. Use this to avoid changing import paths. Warning: Fragile"
+            doc = "An override to override the ros pkg name. Use this to avoid changing import paths. Warning: Fragile",
         ),
     },
 )
@@ -486,7 +486,7 @@ py_ros_interface_collector = rule(
             aspects = [py_ros_generator_aspect],
         ),
         "strip_end": attr.bool(
-            doc = "An override to override the ros pkg name. Use this to avoid changing import paths. Warning: Fragile"
+            doc = "An override to override the ros pkg name. Use this to avoid changing import paths. Warning: Fragile",
         ),
     },
 )

--- a/third_party/legacy_roslaunch/BUILD.bazel
+++ b/third_party/legacy_roslaunch/BUILD.bazel
@@ -21,6 +21,7 @@ py_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//:py_roslib_slim",
         "@ros_comm//:rosmaster",
         "@ros_comm//:rosparam",
         "@ros_comm_msgs//:py_rosgraph_msgs",

--- a/third_party/rosservice/BUILD.bazel
+++ b/third_party/rosservice/BUILD.bazel
@@ -5,6 +5,7 @@ py_library(
     srcs = ["__init__.py"],
     visibility = ["//visibility:public"],
     deps = [
+        "@com_github_mvukov_rules_ros//:py_roslib_slim",
         "@ros_comm//:rosgraph_lib",
         "@ros_comm//:rospy",
         "@ros_genpy//:genpy",


### PR DESCRIPTION
Changelog
===

`ros_test` is broken since `rospy` is dependent on `py_roslib_slim`, but it's removed in PR #1.
Restore `py_roslib_slim` and add `packages.py` to support native ros tools such as roscore.

Testing
===

Run robot app in pennybot repo (`bazel run //bearrobotics/robot/services/pennybot:robot`)
Verified that `roscore`, `bear_bag`, and `bear_param` are fully functional.